### PR TITLE
Updates user table to use 'owner' column instead of 'login'

### DIFF
--- a/priv/repo/migrations/20160615142117_rename_login_field_on_user.exs
+++ b/priv/repo/migrations/20160615142117_rename_login_field_on_user.exs
@@ -1,0 +1,7 @@
+defmodule GithubService.Repo.Migrations.RenameLoginFieldOnUser do
+  use Ecto.Migration
+
+  def change do
+    rename table(:users), :login, to: :owner
+  end
+end

--- a/test/github/fetch_user_test.exs
+++ b/test/github/fetch_user_test.exs
@@ -7,14 +7,14 @@ defmodule GithubService.Github.FetchUserTest do
   @tag :integration
   test "retrieves user information with uppercase name" do
     user = FetchUser.with_username("HackerYou")
-    assert user.login == "hackeryou"
+    assert user.owner == "hackeryou"
   end
 
   @tag :integration
   test "retrieves user information externally" do
     user = FetchUser.with_username("hackeryou")
 
-    assert user.login == "hackeryou"
+    assert user.owner == "hackeryou"
   end
 
   @tag :integration
@@ -23,15 +23,15 @@ defmodule GithubService.Github.FetchUserTest do
 
     found_user = Storage.find_user("hackeryou")
 
-    assert found_user.login == "hackeryou"
+    assert found_user.owner == "hackeryou"
   end
 
   test "retrieves user information locally" do
-    user = %User{login: "hackeryou", public_repos: 12, repos_url: "repo-url" }
+    user = %User{owner: "hackeryou", public_repos: 12, repos_url: "repo-url" }
     Storage.write_user(user)
 
     found_user = FetchUser.with_username("hackeryou")
 
-    assert found_user.login == user.login
+    assert found_user.owner == user.owner
   end
 end

--- a/test/github/storage_test.exs
+++ b/test/github/storage_test.exs
@@ -5,14 +5,14 @@ defmodule GithubService.Github.StorageTest do
   alias GithubService.Github.Storage
 
   test "writes a user to the database" do
-    %User{login: "hackeryou",
+    %User{owner: "hackeryou",
           public_repos: 10,
           repos_url: "repo-url"
     } |> Storage.write_user
 
     user = Storage.find_user("hackeryou")
 
-    assert user.login == "hackeryou"
+    assert user.owner == "hackeryou"
     assert user.public_repos == 10
     assert user.repos_url == "repo-url"
   end

--- a/test/github/transform_user_response_test.exs
+++ b/test/github/transform_user_response_test.exs
@@ -5,13 +5,13 @@ defmodule GithubService.Github.TransformUserResponseTest do
   test "downcases user login" do
     user = TransformUserResponse.convert(raw_response)
 
-    assert user.login == "hackeryou"
+    assert user.owner == "hackeryou"
   end
 
   test "transforms user response" do
     user = TransformUserResponse.convert(raw_response)
 
-    assert user.login == "hackeryou"
+    assert user.owner == "hackeryou"
     assert user.public_repos == 35
     assert user.repos_url == "https://api.github.com/users/HackerYou/repos"
   end

--- a/web/github/storage.ex
+++ b/web/github/storage.ex
@@ -10,7 +10,7 @@ defmodule GithubService.Github.Storage do
   end
 
   def find_user(name) do
-    query = from u in User, where: u.login == ^name, select: u
+    query = from u in User, where: u.owner == ^name, select: u
     Repo.one(query)
   end
 

--- a/web/github/transform_user_response.ex
+++ b/web/github/transform_user_response.ex
@@ -5,7 +5,7 @@ defmodule GithubService.Github.TransformUserResponse do
   def convert(raw_response) do
     raw_response
     |> parse
-    |> downcase_user
+    |> format_owner
     |> remove_date
   end
 
@@ -13,9 +13,17 @@ defmodule GithubService.Github.TransformUserResponse do
     Poison.Parser.parse!(response)
   end
 
-  defp downcase_user(user) do
-    user_login = Map.get(user, "login")
-    %{user | "login" => String.downcase(user_login)}
+  defp format_owner(parsed_response) do
+    parsed_response
+    |> Map.get("login")
+    |> String.downcase
+    |> add_owner(parsed_response)
+    |> Map.delete("login")
+  end
+
+  defp add_owner(owner_name, parsed_response) do
+    parsed_response
+    |> Map.put("owner", owner_name)
   end
 
   defp remove_date(entity) do

--- a/web/github/user.ex
+++ b/web/github/user.ex
@@ -1,9 +1,9 @@
 defmodule GithubService.Github.User do
   use GithubService.Web, :model
-  @derive {Poison.Encoder, only: [:login, :public_repos, :repos_url]}
+  @derive {Poison.Encoder, only: [:owner, :public_repos, :repos_url]}
 
   schema "users" do
-    field :login, :string
+    field :owner, :string
     field :public_repos, :integer
     field :repos_url, :string
 


### PR DESCRIPTION
@Maikon 
For consistency, the name of the column `login` on the `User` table has been renamed to `owner`.
